### PR TITLE
Handle multiple processes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ CFLAGS=-Wall -g -g -O2 -DPREFIX="\"${PREFIX}\"" -fPIC
 LDLIBS= -ldl -lpthread -lnuma
 
 .PHONY: all clean
-all: makefile.dep pinthreads pin.so pinhook.so tests/testhooks tests/delayedthreads
+all: makefile.dep pinthreads pin.so pinhook.so tests/testhooks tests/delayedthreads tests/multipleprocesses
 
 makefile.dep: *.[Cch]
 	for i in *.[Cc]; do ${CC} -MM "$${i}" ${CFLAGS}; done > $@
@@ -25,10 +25,13 @@ tests/testhooks: tests/testhooks.o pinhook.so
 tests/delayedthreads: tests/delayedthreads.o
 	${CC} ${CFLAGS} -o $@ $^ ${LDLIBS}
 
+tests/multipleprocesses: tests/multipleprocesses.o
+	${CC} ${CFLAGS} -o $@ $^ ${LDLIBS}
+
 install:
 	mkdir -p ${PREFIX}/lib/pinthreads/
 	cp pin.so ${PREFIX}/lib/pinthreads/
 	cp pinthreads ${PREFIX}/bin
 
 clean:
-	rm -f *.o *.so makefile.dep pinthreads tests/testhooks tests/delayedthreads tests/*.o
+	rm -f *.o *.so makefile.dep pinthreads tests/testhooks tests/delayedthreads tests/multipleprocesses tests/*.o

--- a/pin.c
+++ b/pin.c
@@ -71,7 +71,14 @@ int sched_setaffinity(pid_t pid, size_t cpusetsize, const cpu_set_t *mask) {
 }
 
 pid_t fork(void) {
-   pid_t ret = old_fork();
+   pid_t ret;
+
+   // When a new process is forked, the refcounter must be incremented
+   pthread_mutex_lock(&get_shm()->pin_lock);
+   get_shm()->refcount++;
+   pthread_mutex_unlock(&get_shm()->pin_lock);
+
+   ret = old_fork();
    if(ret > 0) {
       set_affinity(ret, get_next_core());
    }

--- a/shm.c
+++ b/shm.c
@@ -95,7 +95,10 @@ void cleanup_shm(char *id) {
 
    pthread_mutex_lock(&shm->pin_lock);
    shm->refcount--;
-   if(shm->refcount <= 0) {
+
+   assert(shm->refcount >= 0);
+
+   if(shm->refcount == 0) {
       free_shm = 1;
    }
    pthread_mutex_unlock(&shm->pin_lock);

--- a/tests/multipleprocesses.c
+++ b/tests/multipleprocesses.c
@@ -1,0 +1,18 @@
+#include "../common.h"
+#include <sys/wait.h>
+
+void *fake(void *data) {
+   return NULL;
+}
+
+int main(int argc, char **argv) {
+    pthread_t tid;
+
+    if (fork() == 0) {
+        sleep(1);
+        pthread_create(&tid, NULL, fake, NULL);
+    }
+
+    exit(0);
+}
+


### PR DESCRIPTION
When a fork is done, the child inherits shm information from its father, but need to update the reference counter otherwise the shm segment may be destroyed too soon.

Add an assert to check wrong refcounter values and a test which triggers the assert without the fix.
