### PR TITLE
Add PinThreads server's commands to (dis)allow PinThreads to operate.

### DIFF
--- a/pin.c
+++ b/pin.c
@@ -12,6 +12,9 @@ static pid_t (*old_fork)(void);
 static int (*old_clone)(int (*)(void *), void *, int, void *, ...);
 
 static void set_affinity(pid_t tid, int cpu_id) {
+   if(!get_shm()->active)
+     return;
+
    if(!get_shm()->per_node) {
       cpu_set_t mask;
       CPU_ZERO(&mask);
@@ -38,6 +41,9 @@ int pthread_create(pthread_t *thread, const pthread_attr_t *attr, void *(*start_
    CPU_ZERO(&mask);
 
    ret = old_pthread_create(thread, attr, start_routine, arg);
+
+   if(!get_shm()->active)
+     return ret;
 
    core = get_next_core();
 

--- a/pinserver.c
+++ b/pinserver.c
@@ -137,6 +137,20 @@ void *server(void *data) {
             if(core_to_node[get_shm()->cores[i]] == old_node)
                get_shm()->cores[i] = node_to_cores[new_node][core_id(get_shm()->cores[i])];
          }
+      } else if (action == GET_ACTIVE) {
+	 int active = get_shm()->active;
+  	 VERBOSE("[SERVER] Client asks for active, response is %d\n", active);
+	 send(s2, &active, sizeof(active), 0);
+      }
+      else if (action == SET_ACTIVE) {
+	 int old_active = get_shm()->active;
+	 int new_active = 0;
+
+	 n = recv(s2, &new_active, sizeof(int), 0);
+	 assert(n == sizeof(int));
+
+  	 VERBOSE("[SERVER] Client set active at %d (previous = %d)\n", new_active, old_active);
+	 get_shm()->active = new_active;
       }
 
       close(s2);

--- a/pinserver.c
+++ b/pinserver.c
@@ -59,7 +59,13 @@ void *server(void *data) {
 
    lock_shm();
    if(get_shm()->server_fd == -1) {
-      assert(asprintf(&path, "%s_sock", getenv("PINTHREADS_SHMID")));
+
+      /* allow user to set suffix to facilitate socket retrieval */
+      char *suffix = getenv("PINTHREADS_SOCK_SUFFIX");
+      if (suffix == NULL)
+ 	 assert(asprintf(&path, "%s_sock", getenv("PINTHREADS_SHMID")));
+      else
+ 	 assert(asprintf(&path, "%s_%s_sock", getenv("PINTHREADS_SHMID"), suffix));
 
       if ((s = socket(AF_UNIX, SOCK_STREAM, 0)) == -1) {
          perror("socket");

--- a/pinserver.h
+++ b/pinserver.h
@@ -4,6 +4,8 @@
 #define GET_CORES 0
 #define CHANGE_CORES 1
 #define CHANGE_NODE 2
+#define GET_ACTIVE 3
+#define SET_ACTIVE 4
 
 void init_server(void);
 void wait_for_server(void);

--- a/pinthreads.c
+++ b/pinthreads.c
@@ -10,6 +10,9 @@ void usage(char * app_name) {
    fprintf(stderr, "\t-N: pin per node and not per core\n");
    fprintf(stderr, "\t-s: when not specifying any cores/nodes, you might want to evenly distribute threads on nodes (as opposed to maximize locality)\n");
    fprintf(stderr, "\t-v: verbose (-V verbose on stderr)\n");
+   fprintf(stderr, "\t-S: start server using AF_UNIX socket. The socket file is at\n");
+   fprintf(stderr, "\t    /tmp/shmid[_PINTHREADS_SOCK_SUFFIX]_sock where PINTHREADS_SOCK_SUFFIX\n");
+   fprintf(stderr, "\t    is an optionnal environment variable to facilitate socket retrieval\n");
    exit(EXIT_FAILURE);
 }
 

--- a/shm.c
+++ b/shm.c
@@ -105,7 +105,12 @@ void cleanup_shm(char *id) {
       /* cleanup the socket file with the shm */
       if(shm->server) {
 	char *path = NULL;
-	assert(asprintf(&path, "%s_sock", getenv("PINTHREADS_SHMID")));
+	char *suffix = getenv("PINTHREADS_SOCK_SUFFIX");
+	if (suffix == NULL)
+ 	  assert(asprintf(&path, "%s_sock", getenv("PINTHREADS_SHMID")));
+	else
+	  assert(asprintf(&path, "%s_%s_sock", getenv("PINTHREADS_SHMID"), suffix));
+
         VERBOSE("[SERVER] Delete socket file %s\n", path);
 	unlink(path);
 	free(path);

--- a/shm.c
+++ b/shm.c
@@ -58,6 +58,7 @@ struct shared_state *_create_shm(char *id, int create, struct shared_state *cont
       shm->next_core = 0;
       shm->refcount = 0;
       shm->server_fd = -1;
+      shm->active = 1;
       for(i = 0; i < content->nr_entries_in_cores; i++)
          shm->cores[i] = cores[i];
       pthread_mutex_init(&shm->pin_lock, NULL);
@@ -100,6 +101,15 @@ void cleanup_shm(char *id) {
 
    if(shm->refcount == 0) {
       free_shm = 1;
+
+      /* cleanup the socket file with the shm */
+      if(shm->server) {
+	char *path = NULL;
+	assert(asprintf(&path, "%s_sock", getenv("PINTHREADS_SHMID")));
+        VERBOSE("[SERVER] Delete socket file %s\n", path);
+	unlink(path);
+	free(path);
+      }
    }
    pthread_mutex_unlock(&shm->pin_lock);
 

--- a/shm.h
+++ b/shm.h
@@ -13,6 +13,7 @@ struct shared_state {
    int server_fd;
    int per_node;
    int nr_entries_in_cores;
+   int active;
    int cores[]; // must be the last field
 };
 


### PR DESCRIPTION
When PinThreads is inactive, it will not try to change the affinity of the newly created process/thread, and this new process/thread will inherit the affinity mask from its parent (default Linux behavior).

Server command:
3 = GetActive (PinThreads is currently active or not)
4 = SetActive [int, 0 or 1] -- switch active
